### PR TITLE
Update 2024

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export AWS_PROFILE        ?= sunrise2023-z
+export AWS_PROFILE        ?= sunrise2024-z
 export AWS_DEFAULT_REGION := ap-northeast-1
 
 .PHONY: all deps update fmt test run build clean db upload
@@ -34,7 +34,7 @@ clean:
 
 db:
 	docker run --rm -d \
-	  --name sunrise2023-hakaru-db \
+	  --name sunrise2024-hakaru-db \
 	  -e MYSQL_ROOT_PASSWORD=password \
 	  -e MYSQL_DATABASE=hakaru \
 	  -e TZ=Asia/Tokyo \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ make
 ### launch EC2 instance
 
 - インスタンスタイプ: c5.large
-- キーペア: sunrise2023
+- キーペア: sunrise2024
 - VPC: hakaru
 - サブネット: プライベートサブネット
 - セキュリティグループ: hakaru

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/VG-Tech-Dojo/hakaru
 
-go 1.20
+go 1.23
 
-require github.com/go-sql-driver/mysql v1.7.1
+require github.com/go-sql-driver/mysql v1.8.1
+
+require filippo.io/edwards25519 v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=

--- a/provisioning/ami/Dockerfile
+++ b/provisioning/ami/Dockerfile
@@ -1,13 +1,16 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG TARGETARCH
-ARG VERSION=1.9.2-1
+ARG VERSION=1.11.2-1
 
+# hashicorp.list 作るコマンドは以下が公式ドキュメントに沿ったやり方だが、既知のバグがあるので回避
+#   `apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"`
+# refs. https://unix.stackexchange.com/questions/776941/apt-add-repository-needs-to-run-twice-on-debian-12
 RUN set -x \
     && apt-get update \
     && apt-get install -y curl ca-certificates gnupg lsb-release software-properties-common \
     && curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - \
-    && apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
+    && echo "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list \
     && apt-get update \
     && apt-get install packer=${VERSION}
 

--- a/provisioning/ami/Makefile
+++ b/provisioning/ami/Makefile
@@ -7,7 +7,7 @@ ARTIFACTS_COMMIT := latest
 ARTIFACTS_BUCKET := $(AWS_PROFILE)-hakaru-artifacts
 
 # https://hub.docker.com/r/hashicorp/packer/tags/
-PACKER_VERSION := 1.9.2-1
+PACKER_VERSION := 1.11.2-1
 
 PACKER_IMAGE := sunrise2024/packer:$(PACKER_VERSION)
 

--- a/provisioning/ami/Makefile
+++ b/provisioning/ami/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-AWS_PROFILE ?= sunrise2023-z
+AWS_PROFILE ?= sunrise2024-z
 
 #ARTIFACTS_COMMIT ?= $(shell git rev-parse HEAD)
 ARTIFACTS_COMMIT := latest
@@ -9,7 +9,7 @@ ARTIFACTS_BUCKET := $(AWS_PROFILE)-hakaru-artifacts
 # https://hub.docker.com/r/hashicorp/packer/tags/
 PACKER_VERSION := 1.9.2-1
 
-PACKER_IMAGE := sunrise2023/packer:$(PACKER_VERSION)
+PACKER_IMAGE := sunrise2024/packer:$(PACKER_VERSION)
 
 .PHONY: all clean build scripts.tgz docker
 

--- a/provisioning/ami/_config.pkr.hcl
+++ b/provisioning/ami/_config.pkr.hcl
@@ -1,5 +1,9 @@
 packer {
   required_plugins {
+    amazon-ami-management = {
+      version = "~> 1.5.0"
+      source  = "github.com/wata727/amazon-ami-management"
+    }
     amazon = {
       source  = "github.com/hashicorp/amazon"
       version = "~> 1"

--- a/provisioning/ami/_config.pkr.hcl
+++ b/provisioning/ami/_config.pkr.hcl
@@ -1,8 +1,8 @@
 packer {
   required_plugins {
-    amazon-ami-management = {
-      version = "~> 1.4.1"
-      source  = "github.com/wata727/amazon-ami-management"
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = "~> 1"
     }
   }
 }

--- a/provisioning/ami/hakaru.pkr.hcl
+++ b/provisioning/ami/hakaru.pkr.hcl
@@ -1,7 +1,7 @@
 # https://www.packer.io/docs/builders/amazon/ebs
 source "amazon-ebs" "hakaru" {
   ami_name        = format("hakaru - %s", local.image_time)
-  ami_description = "sunrise2023 hakaru server"
+  ami_description = "sunrise2024 hakaru server"
   region          = "ap-northeast-1"
   ena_support     = true
   sriov_support   = true

--- a/provisioning/ami/scripts/hakaru/Makefile
+++ b/provisioning/ami/scripts/hakaru/Makefile
@@ -38,7 +38,7 @@ app: /root/hakaru/Makefile
 # /root/hakaru/Makefile on ec2 instance
 #
 
-ARTIFACTS_BUCKET ?= sunrise2023-z-hakaru-artifacts
+ARTIFACTS_BUCKET ?= sunrise2024-z-hakaru-artifacts
 ARTIFACTS_COMMIT ?= latest
 
 deploy: clean /root/hakaru/app

--- a/user_data.sh
+++ b/user_data.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-cd /root/hakaru
+cd /root/hakaru || exit 2
 make deploy ARTIFACTS_COMMIT=latest


### PR DESCRIPTION
# 概要
- Sunrise2024 で使えるよう、変更を加えていく
- このリポジトリは sunrise2024-z の AWS アカウントで利用する
  - 学生向けのリポジトリは、このリポジトリをテンプレートとして以下のように作る
    - sunrise2024-a
    - sunrise2024-b
    - sunrise2024-c
    - sunrise2024-d
  - 講師・サポーター向け
    - sunrise2024-y
      - 素振りや動作確認用
    - sunrise2024-z
      - 講師用

# やること
- 2023 -> 2024 にリネーム
- ミドルウェアやパッケージのアップデート
- sunrise2024-z アカウントにデプロイして動作確認するまでの間で起きた不具合の修正