### PR TITLE
go testの探索からdb/dataディレクトリを除外する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 hakaru
 *.tgz
 
-/db/data
-!/db/data/.gitkeep
+!/db/.data
+db/.data/*
+!/db/.data/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ db:
 	  -e MYSQL_DATABASE=hakaru \
 	  -e TZ=Asia/Tokyo \
 	  -p 13306:3306 \
-	  -v $(CURDIR)/db/data:/var/lib/mysql \
+	  -v $(CURDIR)/db/.data:/var/lib/mysql \
 	  -v $(CURDIR)/db/my.cnf:/etc/mysql/conf.d/my.cnf:ro \
 	  -v $(CURDIR)/db/init:/docker-entrypoint-initdb.d:ro \
 	  mysql:8.0.33 \


### PR DESCRIPTION
`go test -v ./...`でdockerにマウントした`db/data`をoepnしようとしてpermission deniedになるので、`db/.data`にして探索から除外する

```sh
❯ make artifacts.tgz
make build GOOS=linux GOARCH=amd64 CGO_ENABLED=0
make[1]: ディレクトリ '/home/right/ghq/github.com/VG-Tech-Dojo/hakaru' に入ります
go mod download
go test -v ./...
pattern ./...: open /home/right/ghq/github.com/VG-Tech-Dojo/hakaru/db/data/#innodb_redo: permission denied
```

Macだとパーミッションが雑なので困らないけどLinuxとかだと困るやつ